### PR TITLE
Publish tasks to workflow specific queues

### DIFF
--- a/client/python/gaia/client.py
+++ b/client/python/gaia/client.py
@@ -229,18 +229,6 @@ def main():
         type=int,
         default=0,
         help='number of workers to launch')
-    parser.add_argument(
-        '--exchange',
-        default=None,
-        help='exchange for worker to receive messages from')
-    parser.add_argument(
-        '--queue',
-        default=None,
-        help='rabbit queue for new workers to connect to')
-    parser.add_argument(
-        '--routing-key',
-        default=None,
-        help='routing key for messages from exchange to get to queue')
 
     args = parser.parse_args()
 

--- a/client/python/gaia/client.py
+++ b/client/python/gaia/client.py
@@ -160,10 +160,6 @@ class Gaia(object):
         # type: (List[str]) -> None
         """Launch the named Sisyphus worker nodes."""
         assert isinstance(names, list), 'need a list of worker names'
-        if metadata:
-            metadata = {
-                'rabbit-' + key: value
-                for key, value in metadata.items()}
         args = [
             {'worker': worker, 'metadata': metadata}
             for worker in names]
@@ -298,20 +294,13 @@ def main():
 
     elif args.command == 'launch':
         workers = ['{}-{}'.format(args.workflow, i) for i in range(args.workers)]
-<<<<<<< HEAD
-        metadata = {}
-        if args.exchange:
-            metadata['exchange'] = args.exchange
-        if args.queue:
-            metadata['queue'] = args.queue
-        if args.routing_key:
-            metadata['routing-key'] = args.routing_key
+        metadata = {
+			'workflow': args.workflow}
 
         flow.launch(workers, metadata)
-=======
-        flow.launch(workers)
+
 
 
 if __name__ == '__main__':
     main()
->>>>>>> 16bd596d9b2e5dd39ce025d7f54e46f72d206b82
+

--- a/client/python/script/launch-sisyphus.sh
+++ b/client/python/script/launch-sisyphus.sh
@@ -12,8 +12,7 @@ then
     FULL_METADATA=$FULL_METADATA,$METADATA
 fi
 
-      --custom-cpu=6 \
-      --custom-memory=32 \
+echo $FULL_METADATA
 
 gcloud compute \
        --project=$PROJECT \
@@ -32,3 +31,8 @@ gcloud compute \
        --boot-disk-device-name=$FULL_NAME \
        --description='sisyphus worker' \
        --metadata=$FULL_METADATA
+
+# additional parameters --------------------
+      # --custom-cpu=6 \
+      # --custom-memory=32 \
+

--- a/client/python/script/launch-sisyphus.sh
+++ b/client/python/script/launch-sisyphus.sh
@@ -3,9 +3,17 @@
 NAME=$1
 FULL_NAME=sisyphus-$NAME
 PROJECT=allen-discovery-center-mcovert
+METADATA=$2
 
-#       --custom-cpu=6 \
-#       --custom-memory=32 \
+FULL_METADATA="base-name=$NAME"
+
+if [ ! -z "$METADATA" ]
+then
+    FULL_METADATA=$FULL_METADATA,$METADATA
+fi
+
+      --custom-cpu=6 \
+      --custom-memory=32 \
 
 gcloud compute \
        --project=$PROJECT \
@@ -22,4 +30,5 @@ gcloud compute \
        --boot-disk-size=200GB \
        --boot-disk-type=pd-standard \
        --boot-disk-device-name=$FULL_NAME \
-       --description='sisyphus worker'
+       --description='sisyphus worker' \
+       --metadata=$FULL_METADATA

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,6 @@
                  [ubergraph "0.5.2"]
                  [protograph "0.0.23"]
                  [polaris "0.0.19"]
-                 [sisyphus "0.0.17"]
+                 [sisyphus "0.0.20"]
                  [com.google.guava/guava "28.0-jre"]
                  [org.javaswift/joss "0.9.17"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject gaia "0.0.17"
+(defproject gaia "0.0.18"
   :description "workflow server"
   :url "http://github.com/prismofeverything/gaia"
   :license {:name "MIT"
@@ -13,6 +13,6 @@
                  [ubergraph "0.5.2"]
                  [protograph "0.0.23"]
                  [polaris "0.0.19"]
-                 [sisyphus "0.0.22"]
+                 [sisyphus "0.0.23"]
                  [com.google.guava/guava "28.0-jre"]
                  [org.javaswift/joss "0.9.17"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject gaia "0.0.16"
+(defproject gaia "0.0.17"
   :description "workflow server"
   :url "http://github.com/prismofeverything/gaia"
   :license {:name "MIT"
@@ -13,6 +13,6 @@
                  [ubergraph "0.5.2"]
                  [protograph "0.0.23"]
                  [polaris "0.0.19"]
-                 [sisyphus "0.0.20"]
+                 [sisyphus "0.0.22"]
                  [com.google.guava/guava "28.0-jre"]
                  [org.javaswift/joss "0.9.17"]])

--- a/resources/config/gaia.clj
+++ b/resources/config/gaia.clj
@@ -13,7 +13,8 @@
 
  :executor
  {:target "sisyphus"
-  :path ""}
+  :path ""
+  :rabbit {}}
 
  :store
  {:type :cloud

--- a/resources/config/gaia.clj
+++ b/resources/config/gaia.clj
@@ -14,7 +14,9 @@
  :executor
  {:target "sisyphus"
   :path ""
-  :rabbit {}}
+  :rabbit {}
+  :project "gcloud-project"
+  :zone "us-west1-b"}
 
  :store
  {:type :cloud

--- a/src/gaia/cloud.clj
+++ b/src/gaia/cloud.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as string]
+   [sisyphus.base :as base]
    [sisyphus.cloud :as cloud]
    [gaia.store :as store]))
 
@@ -9,7 +10,7 @@
   store/Store
   (present?
     [store key]
-    (let [[bucket path] (cloud/split-key key)]
+    (let [[bucket path] (base/split-key key)]
       (cloud/exists? storage bucket (store/join-path [container path]))))
   (protocol [store] "")
   (partition-data
@@ -17,7 +18,7 @@
     (cloud/partition-keys storage data))
   (existing-keys
     [store root]
-    (let [[bucket path] (cloud/split-key root)]
+    (let [[bucket path] (base/split-key root)]
       (cloud/list-directory storage bucket path))))
 
 (defn load-cloud-store

--- a/src/gaia/core.clj
+++ b/src/gaia/core.clj
@@ -12,7 +12,6 @@
    [polaris.core :as polaris]
    [sisyphus.kafka :as kafka]
    [sisyphus.log :as log]
-   [sisyphus.rabbit :as rabbit]
    [gaia.config :as config]
    [gaia.store :as store]
    [gaia.executor :as executor]
@@ -85,17 +84,14 @@
   [config]
   (let [flows (atom {})
         store (config/load-store (:store config))
-        rabbit (rabbit/connect! (:rabbit config))
         kafka (:kafka config)
         producer (kafka/boot-producer kafka)
         kafka (assoc kafka :producer producer)
         exec-config (assoc
                      (:executor config)
-                     :kafka kafka
-                     :rabbit rabbit)
+                     :kafka kafka)
         executor (config/load-executor exec-config)
         state {:config config
-               :rabbit rabbit
                :kafka kafka
                :flows flows
                :store store

--- a/src/gaia/sisyphus.clj
+++ b/src/gaia/sisyphus.clj
@@ -69,7 +69,7 @@
    compute project zone
    (if (empty? filters)
      {}
-     {:filters filters})))
+     {:filter filters})))
 
 (deftype SisyphusExecutor [sisyphus]
   executor/Executor

--- a/src/gaia/sisyphus.clj
+++ b/src/gaia/sisyphus.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.walk :as walk]
    [protograph.template :as template]
+   [sisyphus.log :as log]
    [sisyphus.cloud :as cloud]
    [sisyphus.kafka :as kafka]
    [sisyphus.rabbit :as rabbit]

--- a/src/gaia/sisyphus.clj
+++ b/src/gaia/sisyphus.clj
@@ -48,8 +48,9 @@
   [{:keys [rabbit]} commands step]
   (let [command (get commands (keyword (:command step)))
         task (step->task step command)]
+    (log/debug! "TASK: " task)
     (rabbit/publish!
-     (assoc rabbit :routing-key (:workflow task))
+     (assoc rabbit :routing-key (name (:workflow task)))
      task)
     (assoc task :state :running)))
 


### PR DESCRIPTION
This PR creates the ability to send tasks to specific queues for each workflow. Actually, it doesn't even mention queues because that's not how rabbit works as it turns out, when publishing you just provide the exchange and the routing key, and it gets routed to a queue that is bound to that routing key in that exchange. This required some changes in Sisyphus which is reflected in a version bump for Sisyphus in `project.clj`

In addition, I expanded the launch functionality to include the ability to specify metadata in both `launch-sisyphus.sh` and from the gaia python client in `client/python/gaia/client.py`. I have verified the right metadata fields get set on launch. 