### PR TITLE
List workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,142 +58,8 @@ Once here, you want to be able to send processes and commands to Gaia. First, cl
 
 The python client for Gaia lives at `client/python/gaia.py`.
 
-To connect to a running Gaia server, find the host (open an ssh tunnel to it if needed) and do the following:
+See its [README](client/python/README.md) for details.
 
-```
-import gaia
-config = {'gaia_host': 'localhost:24442'}
-flow = gaia.Gaia(config)
-```
-
-Now that we have a reference to the client, we can call these methods:
-
-* workflows - list current workflows with summary information about each one
-* upload - upload a new workflow
-* command - see what Commands are in a workflow and add new Commands
-* merge - update or add new Steps to a workflow
-* run - recompute dependencies and run outstanding Steps
-* halt - stop a running workflow
-* status - find out all information about a given workflow
-* expire - recompute the given storage keys and Steps and all their dependent Steps
-
-### workflows
-
-The `workflows` method lists the current workflows with summary info about each one.
-
-```python
-flow.workflows()
-```
-
-### upload
-
-To get something running, upload a test workflow:
-
-```
-commands = gaia.load_yaml('../../resources/test/wcm/wcm.commands.yaml')
-steps = gaia.load_yaml('../../resources/test/wcm/wcm.processes.yaml')
-flow.upload('crick_wcm_20191130.121500', dict(owner='crick'), commands, steps)
-```
-
-Each workflow needs a unique name. Best practice is to construct a name in the
-form `owner_program_datetime`.
-
-You will also need to launch some sisyphus workers. To do that
-[Note: This part is in flux]:
-
-```
-flow.launch(['a', 'b'])
-```
-
-Launch more if you want : ) Give each a unique name.
-They will deallocate 5 minutes after finishing their last Steps.
-
-### command
-
-Commands are the base level operations that can be run, specifically: command line programs in a given docker container image. Once defined, a Command can be invoked any number of times with a new set of vars, inputs, and outputs.
-
-If you call this method with an empty or absent array argument, it will just return the Commands in the named workflow.
-
-```
-flow.command('biostream')
-# [{'name': 'ls', 'image': 'ubuntu', ...}, ...]
-```
-
-A Command is expressed as a dictionary with the following keys:
-
-* name - name of the Command
-* image - docker image to run in
-* command - array of shell tokens to execute
-* inputs - map of storage keys to internal paths inside the docker container where the Command's input files will be placed
-* outputs - map of storage keys to internal paths inside the docker container where the Command's output files will be retrieved after the Command has run
-* vars - map of var keys to string values to insert into Command tokens
-
-They may also have an optional `stdout` key which specifies what path to place stdout output (so that stdout can be used as one of the outputs of the command).
-
-```
-flow.command('biostream', [...])
-```
-
-If `flow.command()` is called with an array of Command entries it will merge the given Commands into the workflow, thus adding and/or replacing Commands and triggering the recomputation of any Steps that refer to these Commands.
-
-### merge
-
-Once some Commands exist in the workflow you can start merging in Steps in order to trigger computation. Every Step names a Command and sets the Command's vars, inputs, and outputs. Inputs and outputs refer to paths in the data store while vars are strings that can be spliced into various parts of the Command's shell tokens.
-
-Commands and Steps are kept in *workflows* which are entirely encapsulated from one another. Each workflow has its own data space with its own set of names and values.
-
-To call the `merge` method, provide a workflow name and an array of Steps:
-
-```
-flow.merge('biostream', [{'name': 'ls-home', 'command': 'ls', 'inputs': {...}, ...}, ...])
-```
-
-Each Step is a dictionary with the following keys:
-
-* name - name of the Step
-* command - name of the Command to invoke
-* inputs - map of input keys defined by the Command to keys in the data store to read the input files
-* outputs - map of output keys from the Command to keys in the data store to write the output files after successfully invoking the Command
-* vars - map of var keys to values. If this is an array it will create a Step for each element in the array with the given value
-
-If this is a Step with a name that hasn't been seen before, it will create the Step entry and trigger the computation of outputs if the required inputs are available in the data store.  If the `name` of the Step being merged already exists in the workflow, that Step will be updated and recomputed, along with all Steps that depend on outputs from the updated Step in that workflow.
-
-### run
-
-The `run` method simply triggers the computation in the provided workflow if it is not already running:
-
-```
-flow.run('biostream')
-```
-
-### halt
-
-The `halt` method is the inverse of the `run` method. It will immediately cancel all running tasks and stop the computation in the given workflow:
-
-```
-flow.halt('biostream')
-```
-
-### status
-
-The `status` method provides debugging information about a given workflow. There is a lot of information available. It's formatted as a dictionary with these keys:
-
-* state - a string representing the state of the overall workflow. Possible values are 'initialized', 'running', 'complete', 'halted', and 'error'.
-* flow - contains a representation of the Steps in the workflow as a bipartite graph: `step` and `data`. Each entry has a `from` field containing Step or data names it is dependent on and a `to` field containing all Step or data names dependent on it. 
-* data - contains a map of data keys to their current status: either missing or complete
-* tasks - contains information about each task run through the configured executor. This will largely be executor dependent
-
-```
-flow.status('biostream')
-```
-
-### expire
-
-The `expire` method accepts a workflow and a list of Steps names and/or storage paths (storage keys). It makes those Steps and their dependent Steps have to run again.
-
-```
-flow.expire('biostream', ['ls-home', 'genomes', ...])
-```
 
 ## server
 
@@ -201,7 +67,7 @@ Gaia requires three main components for its operation:
 
 * Executor - This is the service that will be managing the actual execution of all the tasks Gaia triggers. Currently [Sisyphus](https://github.com/CovertLab/sisyphus) is the target.
 * Bus - In order to determine when a task has finished running, Gaia subscribes to an event bus containing messages from the Executor. So far this is [Kafka](https://kafka.apache.org/), but additional busses could easily be supported.
-* Store - The data store is where the inputs and results from each of the running tasks is stored. Currently Gaia supports filesystem, google cloud storage and [Openstack Swift](https://wiki.openstack.org/wiki/Swift) data stores.
+* Store - The data store is where the inputs and results from each of the running tasks is stored. Currently Gaia supports google cloud storage, filesystem, and [Openstack Swift](https://wiki.openstack.org/wiki/Swift) data stores.
 
 ### config
 
@@ -209,28 +75,23 @@ Here is an example of Gaia configuration (living under `resources/config/gaia.cl
 
 ```clj
 {:kafka
- {:base
-  {:host "localhost"        ;; wherever your kafka cluster lives
-   :port "9092"}}
+ {:host "localhost"
+  :port "9092"
+  :status-topic "sisyphus-status"}
+
+ :rabbit
+ {:host "localhost"}
 
  :executor
  {:target "sisyphus"
-  :host "http://localhost:19191"
   :path ""}
 
  :store
- {:type :swift              ;; can also be :file
-  :root ""                  ;; this will prefix all keys in the store
-  :container "biostream"
-  :username "swiftuser"
-  :password "password"
-  :url "http://10.96.11.20:5000/v2.0/tokens"
-  :tenant-name "CCC"
-  :tenant-id "8897b62d8a8d45f38dfd2530375fbdac"
-  :region "RegionOne"}
+ {:type :cloud
+  :root ""}
 
- :flow                      ;; path to set of commands and processes files
- {:path "resources/test/triangle/triangle"}}
+ :flow
+ {:path "resources/test/wcm/wcm"}}
 ```
 
 Once this is all established, you can start Gaia by typing

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -2,37 +2,47 @@
 
 ## running
 
-To connect to a running Gaia server, find the host (open an ssh tunnel to it if needed) and do the following:
+To connect to a running Gaia server, find the host (open an ssh tunnel to it if needed) and do the following
+(optionally passing in a `config` like `{'gaia_host': 'localhost:24442'}`):
 
 ```
 import gaia
-config = {'gaia_host': 'localhost:24442'}
-flow = gaia.Gaia(config)
+flow = gaia.Gaia()
 ```
 
 Now that we have a client object `flow`, we can call these methods:
 
+* workflows - list current workflows with summary information about each one
 * upload - upload a new workflow (properties, Commands, and Steps)
-* workflows - enumerate current workflows with summary information about each one
 * command - see what Commands are available and add new Commands to a new or existing workflow
 * merge - update or add new Steps to a new or existing workflow
 * halt - stop a running workflow
 * run - resume running a workflow
-* status - get debugging details about a given workflow
+* status - get information about a workflow
 * expire - run the Steps needed to (re)-output the given files and/or Steps as well as their dependent Steps
+
+### workflows
+
+To list current workflows with summary info on each one:
+
+```python
+flow.workflows()
+```
 
 ### upload
 
-To get something running, upload a test workflow:
+To get something running, upload a demo workflow:
 
 ```
-commands = gaia.load_yaml('my-commands.yaml')
-steps = gaia.load_yaml('my-steps.yaml')
-flow.upload('crick_experiment_20191130.121500', dict(owner='crick'), commands, steps)
+import json
+commands = json.load('../../resources/test/demo-commands.json')
+steps = json.load('../../resources/test/demo-processes.json')
+flow.upload('crick_demo_20191130.121500', {'owner': 'crick'}, commands, steps)
 ```
 
-Each workflow needs a unique name. Best practice is to construct a name in the
-form `owner_program_datetime`.
+Each workflow needs a unique name. The standard practice is to construct a name in the
+form `owner_program_datetime`. Some code might use that to helpfully sort
+and filter workflows.
 
 You will also need to launch some sisyphus workers. To do that
 [NOTE: This part is in flux]:
@@ -43,15 +53,6 @@ flow.launch(['a', 'b'])
 
 Launch more if you want : ) Give each a unique name.
 They will deallocate 5 minutes after finishing their last Steps.
-
-### workflows
-
-To list current workflows and get info on them as a map from workflow name
-to its summary info:
-
-```python
-flow.workflows()
-```
 
 
 ### command
@@ -67,7 +68,7 @@ flow.command('biostream')
 
 A Command is expressed as a dictionary with the following keys:
 
-* name - name of the Command
+* name - the Command name
 * image - docker image to run in
 * command - array of shell tokens to execute
 * inputs - map of storage keys to internal paths inside the docker container where the Command's input files will be placed
@@ -96,11 +97,12 @@ flow.merge('biostream', [{'name': 'ls-home', 'command': 'ls', 'inputs': {...}, .
 
 Each Step is a dictionary with the following keys:
 
-* name - name of the Step
+* name - the Step name
 * command - name of the Command to invoke
 * inputs - map of input keys defined by the Command to keys in the data store to read the input files
 * outputs - map of output keys from the Command to keys in the data store to write the output files after successfully invoking the Command
 * vars - map of var keys to values. If this is an array it will create a Step for each element in the array with the given value
+* timeout - number of seconds to allow the Step to run
 
 If this is a Step with a name that hasn't been seen before, it will create the Step entry and trigger the computation of outputs if the required inputs are available in the data store.  If the `name` of the Step being merged already exists in the workflow, that Step will be updated and recomputed, along with all Steps that depend on outputs from the updated Step in that workflow.
 
@@ -122,15 +124,21 @@ flow.halt('biostream')
 
 ### status
 
-The `status` method provides debugging information about a given workflow. There is a lot of information available. It's formatted as a dictionary with these keys:
+The `status` method provides information about a workflow, formatted as a
+dictionary with these keys:
 
 * state - a string representing the state of the overall workflow. Possible values are 'initialized', 'running', 'complete', 'halted', and 'error'.
-* flow - contains a representation of the Steps in the workflow as a bipartite graph: `step` and `data`. Each entry has a `from` field containing Step or data names it is dependent on and a `to` field containing all Step or data names dependent on it. 
-* data - contains a map of data keys to their current status: either missing or complete
-* tasks - contains information about each task to run
+* commands - a list of the workflow's commands
+* waiting - info on the Steps waiting to run
 
 ```
 flow.status('biostream')
+```
+
+Or to include internal debugging details from the Gaia server:
+
+```
+flow.status('biostream', debug=True)
 ```
 
 ### expire

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -10,25 +10,32 @@ config = {'gaia_host': 'localhost:24442'}
 flow = gaia.Gaia(config)
 ```
 
-Now that we have a reference to the client, we can call these methods to operate on a named workflow:
+Now that we have a client object `flow`, we can call these methods:
 
-* command - see what Commands are available and add new Commands
-* merge - update or add new Steps
-* run - recompute dependencies and run outstanding Steps
+* upload - upload a new workflow (properties, Commands, and Steps)
+* workflows - enumerate current workflows with summary information about each one
+* command - see what Commands are available and add new Commands to a new or existing workflow
+* merge - update or add new Steps to a new or existing workflow
 * halt - stop a running workflow
-* status - find out all information about a given workflow
-* expire - recompute the given storage keys and Steps and all their dependent Steps
+* run - resume running a workflow
+* status - get debugging details about a given workflow
+* expire - run the Steps needed to (re)-output the given files and/or Steps as well as their dependent Steps
 
-To just get something going, run the workflow in WCM:
+### upload
+
+To get something running, upload a test workflow:
 
 ```
-commands = gaia.load_yaml('../../resources/test/wcm/wcm.commands.yaml')
-wcm = gaia.load_yaml('../../resources/test/wcm/wcm.processes.yaml')
-flow.command('wcm', commands)
-flow.merge('wcm', wcm)
+commands = gaia.load_yaml('my-commands.yaml')
+steps = gaia.load_yaml('my-steps.yaml')
+flow.upload('crick_experiment_20191130.121500', dict(owner='crick'), commands, steps)
 ```
 
-You will also need to launch some sisyphus workers. To do that:
+Each workflow needs a unique name. Best practice is to construct a name in the
+form `owner_program_datetime`.
+
+You will also need to launch some sisyphus workers. To do that
+[NOTE: This part is in flux]:
 
 ```
 flow.launch(['a', 'b'])
@@ -36,6 +43,16 @@ flow.launch(['a', 'b'])
 
 Launch more if you want : ) Give each a unique name.
 They will deallocate 5 minutes after finishing their last Steps.
+
+### workflows
+
+To list current workflows and get info on them as a map from workflow name
+to its summary info:
+
+```python
+flow.workflows()
+```
+
 
 ### command
 
@@ -67,7 +84,7 @@ If `flow.command()` is called with an array of Command entries it will merge the
 
 ### merge
 
-Once some Commands exist in the workflow you can start merging in Steps in order to trigger computation. Every Step names a Command and sets the Command's vars, inputs, and outputs. Inputs and outputs refer to paths in the data store while vars are strings that can be spliced into various parts of the Command's shell tokens.
+Once some Commands exist in the workflow you can start merging in Steps to run. Every Step names a Command and sets the Command's vars, inputs, and outputs. Inputs and outputs refer to paths in the data store. Vars are strings that can be spliced into various parts of the Command's shell tokens.
 
 Commands and Steps are kept in *workflows* which are entirely encapsulated from one another. Each workflow has its own data space with its own set of names and values.
 
@@ -85,7 +102,7 @@ Each Step is a dictionary with the following keys:
 * outputs - map of output keys from the Command to keys in the data store to write the output files after successfully invoking the Command
 * vars - map of var keys to values. If this is an array it will create a Step for each element in the array with the given value
 
-If this is a Step with a name that hasn't been seen before, it will create the Step entry and trigger the computation of outputs if the required inputs are available in the data store.  If the `key` of the Step being merged already exists in the workflow, that Step will be updated and recomputed, along with all Steps that depend on outputs from the updated Step in that workflow.
+If this is a Step with a name that hasn't been seen before, it will create the Step entry and trigger the computation of outputs if the required inputs are available in the data store.  If the `name` of the Step being merged already exists in the workflow, that Step will be updated and recomputed, along with all Steps that depend on outputs from the updated Step in that workflow.
 
 ### run
 
@@ -97,7 +114,7 @@ flow.run('biostream')
 
 ### halt
 
-The 'halt' method is the inverse of the 'run' method. It will immediately cancel all running tasks and stop the computation in the given workflow:
+The `halt` method will immediately cancel all running tasks and stop the computation in the given workflow:
 
 ```
 flow.halt('biostream')
@@ -105,12 +122,12 @@ flow.halt('biostream')
 
 ### status
 
-The `status` method provides information about a given workflow. There is a lot of information available, and it is formatted as a dictionary with these keys:
+The `status` method provides debugging information about a given workflow. There is a lot of information available. It's formatted as a dictionary with these keys:
 
 * state - a string representing the state of the overall workflow. Possible values are 'initialized', 'running', 'complete', 'halted', and 'error'.
 * flow - contains a representation of the Steps in the workflow as a bipartite graph: `step` and `data`. Each entry has a `from` field containing Step or data names it is dependent on and a `to` field containing all Step or data names dependent on it. 
 * data - contains a map of data keys to their current status: either missing or complete
-* tasks - contains information about each task run through the configured executor. This will largely be executor dependent
+* tasks - contains information about each task to run
 
 ```
 flow.status('biostream')
@@ -118,8 +135,8 @@ flow.status('biostream')
 
 ### expire
 
-The `expire` method accepts a workflow and a list of Steps names and data names (storage keys). It makes those Steps and dependent Steps have to run again.
+The `expire` method accepts a workflow and a list of Steps names and storage paths (storage keys). It makes those Steps and their dependent Steps have to run again.
 
 ```
-flow.expire('biostream', ['ls-home', 'genomes', ...])
+flow.expire('biostream', ['ls-home', 'genomes', …])
 ```

--- a/client/python/gaia/client.py
+++ b/client/python/gaia/client.py
@@ -65,7 +65,7 @@ class Gaia(object):
         return requests.post(url, data=data).json()
 
     def command(self, workflow, commands=None):
-        # type: (str, Optional[List[dict]]) -> Dict[Dict[dict]]
+        # type: (str, Optional[List[dict]]) -> dict
         """Add a list of Commands to the named workflow. Return a dict containing
         all of them, {'commands': {name: command, ...}}."""
         if commands is None:
@@ -78,7 +78,7 @@ class Gaia(object):
             'commands': commands})
 
     def merge(self, workflow, steps=None):
-        # type: (str, Optional[List[dict]]) -> List[dict]
+        # type: (str, Optional[List[dict]]) -> dict
         """Merge a list of Steps into the named workflow and start running the
         Steps that can run. Return a list of the workflow's Steps."""
         if steps is None:
@@ -90,15 +90,29 @@ class Gaia(object):
             'workflow': workflow,
             'steps': steps})
 
+    def upload(self, workflow, properties, commands, steps):
+        # type: (str, Dict[str, str], List[dict], List[dict]) -> dict
+        """Upload a new workflow. `properties` should include 'owner'."""
+        assert isinstance(workflow, str)
+        assert isinstance(properties, dict)
+        assert isinstance(commands, list)
+        assert isinstance(steps, list)
+
+        return self._post('upload', {
+            'workflow': workflow,
+            'properties': properties,
+            'commands': commands,
+            'steps': steps})
+
     def run(self, workflow):
-        # type: (str) -> None
+        # type: (str) -> dict
         """Start running the named workflow. Usually this happens automatically."""
         assert isinstance(workflow, str)
         return self._post('run', {
             'workflow': workflow})
 
     def halt(self, workflow):
-        # type: (str) -> None
+        # type: (str) -> dict
         """Stop running the named workflow."""
         assert isinstance(workflow, str)
         return self._post('halt', {
@@ -112,7 +126,7 @@ class Gaia(object):
             'workflow': workflow})
 
     def expire(self, workflow, keys):
-        # type: (str, List[str]) -> None
+        # type: (str, List[str]) -> dict
         """Expire outputs and downstream dependencies given storage keys and/or Step names."""
         assert isinstance(workflow, str)
         assert isinstance(keys, list), 'need a list of storage keys and/or Step names'
@@ -120,6 +134,11 @@ class Gaia(object):
         return self._post('expire', {
             'workflow': workflow,
             'expire': keys})
+
+    def workflows(self):
+        # type () -> dict
+        """List the current workflows, with summary info on each one."""
+        return self._post('workflows', {})
 
     def launch(self, names):
         # type: (List[str]) -> None

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
 	name='gaia',
-	version='0.0.7',
+	version='0.0.8',
 	packages=['gaia'],
 	author='Ryan Spangler',
 	author_email='ryan.spangler@gmail.com',

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject gaia "0.0.15"
-  :description "regenerating dependency network"
+(defproject gaia "0.0.16"
+  :description "workflow server"
   :url "http://github.com/prismofeverything/gaia"
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}

--- a/resources/config/gaia.clj
+++ b/resources/config/gaia.clj
@@ -3,11 +3,6 @@
   :port "9092"
   :status-topic "sisyphus-status"}
 
- :mongo
- {:host "127.0.0.1"
-  :port 27017
-  :database "test"}
-
  :rabbit
  {:host "localhost"}
 

--- a/resources/config/lab.clj
+++ b/resources/config/lab.clj
@@ -3,11 +3,6 @@
   :port "9092"
   :status-topic "sisyphus-status"}
 
- :mongo
- {:host "127.0.0.1"
-  :port 27017
-  :database "test"}
-
  :rabbit
  {}
 

--- a/resources/test/demo-commands.json
+++ b/resources/test/demo-commands.json
@@ -1,0 +1,34 @@
+[
+    {
+        "command": [
+            "python",
+            "-u",
+            "-c",
+            "with open('/tmp/lines.txt', 'w') as f:\n  for i in range(100):\n    f.write('This is line {}\\n'.format(i))\n    print('hello {}'.format(i))"
+        ],
+        "image": "python:2.7.16",
+        "inputs": {},
+        "name": "lines",
+        "outputs": {
+            "0": ">>",
+            "1": "/tmp/lines.txt"
+        },
+        "vars": {}
+    },
+    {
+        "command": [
+            "wc",
+            "/tmp/lines.txt"
+        ],
+        "image": "python:2.7.16",
+        "inputs": {
+            "0": "/tmp/lines.txt"
+        },
+        "name": "count",
+        "outputs": {
+            "0": ">>",
+            "1": ">"
+        },
+        "vars": {}
+    }
+]

--- a/resources/test/demo-steps.json
+++ b/resources/test/demo-steps.json
@@ -1,0 +1,24 @@
+[
+    {
+        "command": "lines",
+        "inputs": {},
+        "name": "lines",
+        "outputs": {
+            "0": "sisyphus-jerry:DemoWorkflow/20191202.115929/logs/lines.log",
+            "1": "sisyphus-jerry:DemoWorkflow/20191202.115929/lines.txt"
+        },
+        "timeout": 10
+    },
+    {
+        "command": "count",
+        "inputs": {
+            "0": "sisyphus-jerry:DemoWorkflow/20191202.115929/lines.txt"
+        },
+        "name": "count",
+        "outputs": {
+            "0": "sisyphus-jerry:DemoWorkflow/20191202.115929/logs/count.log",
+            "1": "sisyphus-jerry:DemoWorkflow/20191202.115929/count.txt"
+        },
+        "timeout": 10
+    }
+]

--- a/src/gaia/command.clj
+++ b/src/gaia/command.clj
@@ -21,7 +21,7 @@
 
 (defn validate-apply-composite!
   [{:keys [inputs outputs]} step]
-  ;; (log/debug! "VALIDATE" (pp step))
+  ;; (log/debug! "validate" (pp step))
   (let [pin (:inputs step)
         pout (:outputs step)
         pvars (:vars step)]

--- a/src/gaia/config.clj
+++ b/src/gaia/config.clj
@@ -63,6 +63,9 @@
     (assoc config :commands commands)))
 
 (defn load-store
+  "Use the given config to construct a store/Store generator function, which
+  given the workflow name to use as a container base path will then connect to
+  a service for storing task inputs and outputs, each with a local key."
   [config]
   (condp = (keyword (:type config))
     :file (store/file-store-generator config)

--- a/src/gaia/core.clj
+++ b/src/gaia/core.clj
@@ -47,7 +47,7 @@
   useful for debugging but doesn't promise API results that client code can
   depend on."
   [data]
-  (walk/postwalk
+  (walk/prewalk
    (fn [node]
      (if (atom? node)
        @node

--- a/src/gaia/core.clj
+++ b/src/gaia/core.clj
@@ -15,6 +15,7 @@
    [sisyphus.rabbit :as rabbit]
    [gaia.config :as config]
    [gaia.store :as store]
+   [gaia.util :as util]
    [gaia.executor :as executor]
    [gaia.command :as command]
    [gaia.flow :as flow]
@@ -182,9 +183,7 @@
 (defn workflows-info
   "Return a map of workflow names to their summary info."
   [{:keys [flows] :as state}]
-  (into {}
-        (map (fn [[workflow flow]] [workflow (sync/summarize-flow flow)])
-             @flows)))
+  (util/map-vals sync/summarize-flow @flows))
 
 (defn command-handler
   "Merge the given commands (transformed to a keyword -> value map `index`) into
@@ -328,13 +327,6 @@
     (println config)
     (http/start-server app {:port 24442})
     state))
-
-;(defn load-yaml
-;  [key config-path step-path]
-;  (let [config (config/read-path config-path)
-;        state (boot config)
-;        state (load-steps! state key step-path)]
-;    (run-flow! state key)))
 
 (defn -main
   [& args]

--- a/src/gaia/sync.clj
+++ b/src/gaia/sync.clj
@@ -318,7 +318,7 @@
 (defn merge-properties!
   "Merge the given properties into the workflow, computing some defaults."
   [{:keys [properties workflow] :as state} new-properties]
-  (let [default-owner (first (string/split workflow #"_" 2))
+  (let [default-owner (first (string/split (name workflow) #"_" 2))
         default-properties {:owner default-owner}
         new-properties (merge default-properties new-properties)]
     (log-debug-if! "merging properties" (keys new-properties))

--- a/src/gaia/sync.clj
+++ b/src/gaia/sync.clj
@@ -41,13 +41,12 @@
 
 (defn summarize-flow
   "Return summary info on a workflow for the 'workflows' endpoint.
-  TODO(jerry): Counts of waiting/ready/running/completed tasks."
+  TODO(jerry): Include counts of waiting/ready/running/completed steps."
   [flow]
-  (let [{:keys [state tasks]} @(:status flow)]
+  (let [{:keys [state]} @(:status flow)]
     {:name (name (:workflow flow))
-     :owner (:owner (:properties flow))
-     :state state
-     :task-count (count tasks)}))
+     :owner (:owner @(:properties flow))
+     :state state}))
 
 (def running-states
   #{:running :error :exception})
@@ -343,7 +342,8 @@
 (defn expire-commands!
   [{:keys [flow] :as state} executor expiring]
   (let [steps (template/map-cat (partial flow/command-steps @flow) expiring)]
-    (log/debug! "expiring steps" steps "from commands" (into [] expiring))
+    (when (seq steps)
+      (log/debug! "expiring steps" steps "from commands" (into [] expiring)))
     (expire-keys! state executor steps)))
 
 (defn merge-commands!

--- a/src/gaia/util.clj
+++ b/src/gaia/util.clj
@@ -1,0 +1,12 @@
+(ns gaia.util
+  )
+
+(defn map-vals
+  "Map a function over a map's values."
+  [f m]
+  (reduce-kv (fn [m k v] (assoc m k (f v))) {} m))
+
+(defn map-keys
+  "Map a function over a map's keys."
+  [f m]
+  (reduce-kv (fn [m k v] (assoc m (f k) v)) {} m))


### PR DESCRIPTION
* Add a first cut `/workflows` endpoint that lists workflows with summary info about each one.
  * TODO: Include counts of waiting/ready/running/completed steps in the result. I didn't figure out how to get that info.
* Add an `/upload` endpoint which uploads a workflow in one request: commands, steps, and properties.
* Remove internal guts from the `\status` endpoint's response unless the request sets `debug: True`.
* Suppress `expiring` debug-log messages when the list is empty.
* Don't shout in debug log messages.
* Add some docstrings.
* Comment out the unused load-yaml feature.
* Add a demo workflow from wcEcoli's `runscripts/cloud/util/demo_workflow.py`.
* Improve the python Gaia client's debug CLI: Test the `upload` and `workflow` endpoints, make the config arg optional, print the response from the `expire` endpoint, which proved to be internal guts, so fix that.