### PR TITLE
include all properties in WF summary; fix error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Once here, you want to be able to send processes and commands to Gaia. First, cl
 ## client
 
 The python client for Gaia lives at `client/python/gaia.py`.
+It sends HTTP requests to the Gaia server.
 
 See its [README](client/python/README.md) for details.
+The README and `gaia.py` document Gaia's HTTP API.
 
 
 ## server

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -41,8 +41,8 @@ flow.upload('crick_demo_20191130.121500', {'owner': 'crick'}, commands, steps)
 ```
 
 Each workflow needs a unique name. The standard practice is to construct a name in the
-form `owner_program_datetime`. Some code might use that to helpfully sort
-and filter workflows.
+form `owner_program_datetime`, e.g. `crick_DemoWorkflow_20191209.133734`.
+This aids sorting and filtering workflows.
 
 You will also need to launch some sisyphus workers. To do that
 [NOTE: This part is in flux]:
@@ -128,8 +128,8 @@ The `status` method provides information about a workflow, formatted as a
 dictionary with these keys:
 
 * state - a string representing the state of the overall workflow. Possible values are 'initialized', 'running', 'complete', 'halted', and 'error'.
-* commands - a list of the workflow's commands
-* waiting - info on the Steps waiting to run
+* commands - a list of the workflow's Commands
+* waiting-inputs - a list of the data inputs (file and directory paths) that Steps are waiting on
 
 ```
 flow.status('biostream')

--- a/client/python/gaia/client.py
+++ b/client/python/gaia/client.py
@@ -69,10 +69,15 @@ class Gaia(object):
         url = self.protocol + self.host + '/' + endpoint
         reply = requests.post(url, json=data, timeout=5)
 
-        result = reply.json()
+        try:
+            result = reply.json()
+        except ValueError as e:
+            result = reply.text
+
         if reply.status_code != requests.codes.ok and result:
             raise requests.HTTPError(result)
         reply.raise_for_status()
+
         return result
 
     def command(self, workflow, commands=None):

--- a/client/python/gaia/client.py
+++ b/client/python/gaia/client.py
@@ -62,10 +62,18 @@ class Gaia(object):
         self.host = config.get('gaia_host', 'localhost:24442')
 
     def _post(self, endpoint, data):
+        """Post to the endpoint with JSON data. Might raise a HTTPError or
+        another subtype of requests.RequestException.
+        """
         # type: (str, dict) -> dict
         url = self.protocol + self.host + '/' + endpoint
-        data=json.dumps(data)
-        return requests.post(url, data=data).json()
+        reply = requests.post(url, json=data, timeout=5)
+
+        result = reply.json()
+        if reply.status_code != requests.codes.ok and result:
+            raise requests.HTTPError(result)
+        reply.raise_for_status()
+        return result
 
     def command(self, workflow, commands=None):
         # type: (str, Optional[List[dict]]) -> dict
@@ -219,16 +227,7 @@ def main():
 
     if args.command == 'status':
         status = flow.status(args.workflow)['status']
-        print('Status:')
         pp.pprint(status)
-
-        commands = flow.command(args.workflow)
-        print('\nCommands:')
-        pp.pprint(commands)
-
-        steps = flow.merge(args.workflow)
-        print('\nSteps:')
-        pp.pprint(steps)
 
     elif args.command == 'upload':
         if not args.path:
@@ -240,17 +239,23 @@ def main():
             commands = load_yaml('{}commands.yaml'.format(args.path))
             steps = load_yaml('{}steps.yaml'.format(args.path))
 
-        print(commands)
-        print(steps)
+        print('\nCommands to upload:')
+        pp.pprint(commands)
+
+        print('\nSteps to upload:')
+        pp.pprint(steps)
 
         properties = {
             'owner': os.environ['USER'],
             }
-        flow.upload(
+
+        print('\nResponse:')
+        response = flow.upload(
             workflow=args.workflow,
             properties=properties,
             commands=commands,
             steps=steps)
+        pp.pprint(response)
 
     elif args.command == 'workflows':
         workflows = flow.workflows()

--- a/src/gaia/core.clj
+++ b/src/gaia/core.clj
@@ -38,10 +38,12 @@
    (string/split (slurp path) #"\n")))
 
 (defn json-response
-  [body]
-  {:status 200
-   :headers {"content-type" "application/json"}
-   :body (json/generate-string body)})
+  ([body]
+   (json-response body 200))
+  ([body status-code]
+   {:status status-code
+    :headers {"content-type" "application/json"}
+    :body (json/generate-string body)}))
 
 (defn serializable
   "Make internal data JSON-serializable by expanding each atom's value. This is
@@ -118,6 +120,11 @@
 
 (defn merge-properties!
   "Merge the new properties into the named workflow."
+  ;   :owner - owner name for filtering and sorting workflow lists
+  ;   :description - to organize workflows
+  ;   Requested number of workers?
+  ;   Worker node resource needs?
+  ;   Storage root path?
   [state workflow properties]
   (let [flow (find-flow! state workflow)]
     (sync/merge-properties! flow properties)
@@ -136,11 +143,6 @@
   (let [flow (find-flow! state workflow)]
     (sync/merge-steps! flow executor steps)
     state))
-
-;(defn load-steps!
-;  [state workflow path]
-;  (let [steps (config/parse-yaml path)]
-;    (merge-steps! state workflow steps)))
 
 (defn run-flow!
   [{:keys [executor] :as state} workflow]
@@ -307,10 +309,11 @@
     (try
       (handler request)
       (catch Exception e
-        (log/exception! e "bad request" request)
-        (json-response
-         {:error "bad request"
-          :request request})))))
+        ; TODO: The request body is just an empty stream now.
+        ;   Adopt ring-json/wrap-json-response and ring-json/wrap-json-params to
+        ;   log the request body?
+        (log/exception! e "Bad Request") ; or 500 Internal Server Error
+        (json-response {:error (str e)} 400))))) ; TODO: just (.getMessage e)?
 
 (defn start
   [options]

--- a/src/gaia/core.clj
+++ b/src/gaia/core.clj
@@ -169,10 +169,12 @@
   (let [flow (find-flow! state workflow)
         {:keys [state data tasks]} @(:status flow)
         complete (sync/complete-keys data)
+        ; TODO(jerry): :state is in #{:initialized :running :complete :halted :error}?
+        ;   Add a :stalled state?
+        ; TODO(jerry): Add :steps.
         status {:state state
                 :commands @(:commands flow)
-                ; TODO(jerry): Add :steps.
-                :waiting (flow/missing-data @(:flow flow) complete)}
+                :waiting-inputs (flow/missing-data @(:flow flow) complete)}
         status (if debug ; include internal guts
                  (merge status
                         (serializable

--- a/src/gaia/flow.clj
+++ b/src/gaia/flow.clj
@@ -100,6 +100,7 @@
    :outgoing (graph/successors flow node)})
 
 (defn missing-data
+  "Return a list of input paths that steps are waiting on."
   [flow data]
   (let [steps (map-prefix "step" (step-nodes flow))
         full (map (partial full-node flow) steps)

--- a/src/gaia/sync.clj
+++ b/src/gaia/sync.clj
@@ -24,14 +24,12 @@
     (log/info! message if-seq)))
 
 (defn- guess-owner
-  "Guess a default :owner name from a workflow name like
-  owner_type_timestamp or owner_type_timestamp__description."
+  "Guess a default :owner name from a workflow name like owner_type_timestamp."
   [workflow]
   (first (string/split (name workflow) #"_" 2)))
 
 (defn- guess-properties
   "Guess default properties from a workflow name."
-  ; Also extract :description from owner_type_timestamp__description?
   [workflow]
   {:owner (guess-owner workflow)})
 

--- a/src/gaia/sync.clj
+++ b/src/gaia/sync.clj
@@ -58,6 +58,7 @@
   (let [{:keys [state]} @(:status flow)
         properties @(:properties flow)]
     {:name (name (:workflow flow))
+     :state state
      :properties properties}))
 
 (def running-states

--- a/src/gaia/sync.clj
+++ b/src/gaia/sync.clj
@@ -59,7 +59,8 @@
         properties @(:properties flow)]
     {:name (name (:workflow flow))
      :state state
-     :properties properties}))
+     :properties properties
+     :step-count (count (flow/step-nodes @(:flow flow)))}))
 
 (def running-states
   #{:running :error :exception})


### PR DESCRIPTION
* Include all properties in the list-workflows summary. Treat `:owner` specially only to compute a default value.
* Provide a useful exception in the Gaia client rather than burying the info behind client and server side JSON exceptions.
* Per the `requests` doc: Always set the HTTP timeout in production code. How about 5 seconds? That's just for waiting time. It doesn't count data transfer time.
