### PR TITLE
Declare queue before publishing

### DIFF
--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
 	name='gaia',
-	version='0.0.8',
+	version='0.0.9',
 	packages=['gaia'],
 	author='Ryan Spangler',
 	author_email='ryan.spangler@gmail.com',

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject gaia "0.0.18"
+(defproject gaia "0.0.19"
   :description "workflow server"
   :url "http://github.com/prismofeverything/gaia"
   :license {:name "MIT"
@@ -13,6 +13,6 @@
                  [ubergraph "0.5.2"]
                  [protograph "0.0.23"]
                  [polaris "0.0.19"]
-                 [sisyphus "0.0.23"]
+                 [sisyphus "0.0.24"]
                  [com.google.guava/guava "28.0-jre"]
                  [org.javaswift/joss "0.9.17"]])

--- a/src/gaia/sisyphus.clj
+++ b/src/gaia/sisyphus.clj
@@ -49,9 +49,12 @@
   [{:keys [rabbit]} commands step]
   (let [command (get commands (keyword (:command step)))
         task (step->task step command)
-        routing-key (str (name (:workflow task)) "-task")]
+        workflow-name (name (:workflow task))
+        queue-name (str workflow-name "-queue")
+        routing-key (str workflow-name "-task")]
     (log/debug! "rabbit:" (:exchange rabbit) routing-key)
     (log/debug! "task:" task)
+    (rabbit/declare-queue! rabbit queue-name routing-key)
     (rabbit/publish!
      (assoc rabbit :routing-key routing-key)
      task)


### PR DESCRIPTION
This PR declares the binding between a queue and a routing-key on an exchange from the publishing side, so that it can still publish a message before the worker has booted. 